### PR TITLE
Update 20-mf832s.sh

### DIFF
--- a/etc/hotplug.d/usb/20-mf832s.sh
+++ b/etc/hotplug.d/usb/20-mf832s.sh
@@ -29,3 +29,6 @@ NETIF=network.interface.mf832s
         ubus call $NETIF up ; } ||\
         logger -t hotplug "MF832S: $MODEM chat fail" ||\
     exit ; }
+ifconfig eth1 up
+sleep 20s
+udhcpc -i eth1


### PR DESCRIPTION
实现初始化时调用udhcpc命令,免去手工调用过程. ifconfig命令是为了强制启动网卡(有时候系统默认是没有开启该网卡,测试多个openwrt版本,结果系统默认不一致,故此处强制启动)